### PR TITLE
Properly handle non-HTTP 200 status codes gracefully

### DIFF
--- a/code/webcast/webcast.py
+++ b/code/webcast/webcast.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
 from requests import get
-from os import system, path
+from requests.exceptions import HTTPError
+from os import system, path, sys
 import logging
 import time
 import json
@@ -31,7 +32,11 @@ with open(f"/etc/webcast/webcast.conf") as f:
 if config['auto'] == "true":
     # Get the Config file from the Church
     request = get(config['url'])
-    request.raise_for_status()
+    try:
+        request.raise_for_status()
+    except HTTPError as err:
+        logger.error("HTTP Error: {0}".format(err))
+        sys.exit("Unable to fetch configuration.")
     xml = request.text
     logger.info("Successfully retrieved XML file")
 

--- a/code/webcast/webcast.py
+++ b/code/webcast/webcast.py
@@ -30,7 +30,9 @@ with open(f"/etc/webcast/webcast.conf") as f:
 
 if config['auto'] == "true":
     # Get the Config file from the Church
-    xml = get(config['url']).text
+    request = get(config['url'])
+    request.raise_for_status()
+    xml = request.text
     logger.info("Successfully retrieved XML file")
 
     # Video Bitrate


### PR DESCRIPTION
**Reasoning:** 
Occasionally the church website will overload, and will start returning HTTP 500 errors. 

**What this does:**
This more gracefully handles those errors, and doesn't try to parse XML on it's output.

**Example output:**
Jan 13 04:38:55 webcast systemd[1]: Started Stream Manager.
Jan 13 04:38:56 webcast webcast.py[4263]: ERROR: HTTP Error: 404 Client Error: Not Found for url: https://raw.githubusercontent.com/ChickenDevs/webcast/main/test-404.xml
Jan 13 04:38:56 webcast webcast.py[4263]: Unable to fetch configuration.
Jan 13 04:38:56 webcast systemd[1]: webcast.service: Main process exited, code=exited, status=1/FAILURE
Jan 13 04:38:56 webcast systemd[1]: webcast.service: Failed with result 'exit-code'.

**How to test:**
Set URL to: https://raw.githubusercontent.com/ChickenDevs/webcast/main/test-404.xml
and wait a minute for the service to restart, then click "Status"